### PR TITLE
YOLO: Handle Line Intersections and Robots

### DIFF
--- a/yolo/createYoloLabels.py
+++ b/yolo/createYoloLabels.py
@@ -90,7 +90,7 @@ for d in datasets:
                     if annotation['type'] == "ball":
                         classid = 0
                     # we only learn goalposts, so the side doesn't matter to us
-                    elif annotation['type'] == "right_goalpost" or annotation['type'] == "left_goalpost":
+                    elif annotation['type'] == "goalpost":
                         classid = 1
                     elif annotation['type'] == "robot":
                         classid = 2

--- a/yolo/createYoloLabels.py
+++ b/yolo/createYoloLabels.py
@@ -37,6 +37,8 @@ for d in datasets:
                 # in some YAMLS the width and height is not given
                 # then we need to calculate it ourselves by looking at the image
                 else:
+                    #imgwidth = 1920
+                    #imgheight = 1080
                     img_full_path = os.path.join(d, name)
                     im = cv2.imread(img_full_path)
                     imgheight, imgwidth, _ = im.shape
@@ -92,7 +94,7 @@ for d in datasets:
                 else:
                     pass
 
-        imgname = name.replace(".png", "").replace(".jpg", "")
+        imgname = name.lower().replace(".png", "").replace(".jpg", "")
         with open(d + "/" + imgname + ".txt", "w+") as output:
             for e in annolist:
                 output.write(e + "\n")

--- a/yolo/createYoloLabels.py
+++ b/yolo/createYoloLabels.py
@@ -70,7 +70,6 @@ for d in datasets:
 
                     # TODO this needs to be changed from hand for now
                     # image tagger types
-                    '''
                     if annotation['type'] == "ball":
                         classid = 0
                     elif annotation['type'] == "goalpost":
@@ -83,23 +82,10 @@ for d in datasets:
                         classid = 4
                     elif annotation['type'] == "X-Intersection":
                         classid = 5
-                    else:
-                        print(f"Unknown Annotation Type: {annotation['type']}")
-                    '''
-
-                    if annotation['type'] == "ball":
-                        classid = 0
-                    # we only learn goalposts, so the side doesn't matter to us
-                    elif annotation['type'] == "goalpost":
-                        classid = 1
-                    elif annotation['type'] == "robot":
-                        classid = 2
                     elif annotation['type'] == "top_bar":
-                        classid = 3
+                        classid = 6
                     else:
                         print(f"Unknown Annotation Type: {annotation['type']}")
-
-
 
 
                     annolist.append("{} {} {} {} {}".format(classid, relcenter_x, relcenter_y, relannowidth, relannoheight,))

--- a/yolo/createYoloLabels.py
+++ b/yolo/createYoloLabels.py
@@ -54,8 +54,8 @@ for d in datasets:
                         # so we assume the point is in the middle
                         # and then make a box of 5% of the image in all directions
                         coords = annotation['vector'][0]
-                        relcenter_x = coords[0]
-                        relcenter_y = coords[1]
+                        relcenter_x = coords[0] / imgwidth
+                        relcenter_y = coords[1] / imgheight
                         relannowidth = 0.05
                         relannoheight = 0.05
 


### PR DESCRIPTION
Since line intersections are only labeled as a single point, we have to make a bounding box around the single coordinate. This solution handles it by just having a bounding box of 5% of the height and width of the image.

This also handles robots.

It also handles the slightly different dataset format.