### PR TITLE
Yolo annotation generation: also use root directory and allow non .yaml directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Since the used methods can be very different, we will explain them individually:
 
 
 ### Create labels for training
-We provide [createYoloLabels.py](https://github.com/bit-bots/AutoImageLabeler/blob/master/yolo/createYoloLabels.py).
-The script currently works for the classes ball, goalpost, robot, L-Intersection, T-Intersection, X-Intersection, and the crossbar.
-For the intersections we create a bounding box of 5% of the image height and 5% of the image width.
+We provide a script for creating YOLO labels ([createYoloLabels.py](https://github.com/bit-bots/AutoImageLabeler/blob/master/yolo/createYoloLabels.py)) based on the [TORSO-21](https://github.com/bit-bots/TORSO_21_dataset) Dataset annotation format.
+The script currently works for the classes `ball`, `goalpost`, `robot`, `L-Intersection`, `T-Intersection`, `X-Intersection`, and the `crossbar`.
+For the intersections, we create a bounding box of 5% of the image height and 5% of the image width.
 The labels must be provided in the form of a yaml file.
-You can call the script with e.g. `python3 createYoloLabels.py /foo/imagesets`.
-The path should be an absolute path.
+You can call the script with e.g. `python3 createYoloLabels.py /absolute/path/to/imagesets/`.
 To handle multiple imagesets the script ignores images and yaml files in the `imagesets` folder itself and expects them in subfolders.
 If you only have one imageset, then your images and yaml file need to be in e.g. `/foo/imagesets/actualImageset`.
 You do not need to specify the path to the .yaml file, the script searches for them in all subfolders of the given path.
@@ -33,9 +32,9 @@ Otherwise, the filepaths might not be correct.
 We assume if and only if an annotation (including "not in image") exists for an image, it should be used in the training.
 
 ###### TL;DR
-`python3 createYoloLabels.py /foo/imagesets`
+`python3 createYoloLabels.py /absolute/path/to/imagesets/`
 
-where /foo/imagesets is an absolute path and one level above the folders containing images.
+where /absolute/path/to/imagesets/ is an absolute path and one level above the folders containing images.
 
 ### When you already have a trained YOLO
 We assume that you only need predictions for a bounding box.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ The script currently works for the classes `ball`, `goalpost`, `robot`, `L-Inter
 For the intersections, we create a bounding box of 5% of the image height and 5% of the image width.
 The labels must be provided in the form of a yaml file.
 You can call the script with e.g. `python3 createYoloLabels.py /absolute/path/to/imagesets/`.
-To handle multiple imagesets the script ignores images and yaml files in the `imagesets` folder itself and expects them in subfolders.
-If you only have one imageset, then your images and yaml file need to be in e.g. `/foo/imagesets/actualImageset`.
-You do not need to specify the path to the .yaml file, the script searches for them in all subfolders of the given path.
+You do not need to specify the path to the .yaml file, the script searches for them in the root directory and all subfolders of the given path.
 It assumes the .yaml file is in the same folder as the images for which it contains annotations.
 The script assumes your images use one of the following fileendings: `.jpg, .JPG, .png, .PNG`
 
@@ -33,8 +31,6 @@ We assume if and only if an annotation (including "not in image") exists for an 
 
 ###### TL;DR
 `python3 createYoloLabels.py /absolute/path/to/imagesets/`
-
-where /absolute/path/to/imagesets/ is an absolute path and one level above the folders containing images.
 
 ### When you already have a trained YOLO
 We assume that you only need predictions for a bounding box.

--- a/yolo/createYoloLabels.py
+++ b/yolo/createYoloLabels.py
@@ -10,7 +10,6 @@ if len(sys.argv[0]) == 0:
 else:
     directory = sys.argv[1]
 datasets = [x[0] for x in os.walk(directory)]  # generate a list of all subdirectories (including root directory)
-datasets = datasets[1:]  # remove root directory
 print("The following datasets will be considered:")
 for d in datasets:
     print(d)
@@ -23,8 +22,13 @@ for d in datasets:
     if len(yamlfile) > 1:
         print(f"There was more than one yaml file in {d}, this is probably unwanted...")
         print("I will use {} now. Be careful if this is not the one you expected me to use.".format(yamlfile[0]))
-    with open(yamlfile[0]) as f:
-        export = yaml.safe_load(f)
+    if yamlfile != []: # skip folders when no yaml found
+        with open(yamlfile[0]) as f:
+            export = yaml.safe_load(f)
+    else:
+        print() #  empty line to make output more readable
+        print(f"Found no yaml in {d}")
+        continue
 
     for name, frame in export['images'].items():
         trainImages.append(f"{d}/{name}")


### PR DESCRIPTION
This pull request also allows that data is in the root directory and the script will now generate yolo annotations for these too.
This also fixes an issue where having a directory which did not contain a .yaml file crashed the script.